### PR TITLE
Always write to response

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -116,19 +116,22 @@ module.exports = function(options){
             if (debug) { log('render', options.response ? '<response>' : sassPath); }
             imports[sassPath] = paths;
 
-            // Send compiled CSS into response rather than writing to file
-            if (options.response) {
-              res.writeHead(200, {
-                'Content-Type': 'text/css',
-                'Cache-Control': 'max-age=0'
-              });
-              return res.end(css);
+            // If response is falsey, also write to file
+            if (!options.response) {
+                mkdirp(dirname(cssPath), 0700, function(err){
+                    if (err) return error(err);
+                    fs.writeFile(cssPath, css, 'utf8', function(err) {
+                        if (err) return error(err);
+                    });
+                });
             }
 
-            mkdirp(dirname(cssPath), 0700, function(err){
-              if (err) { return error(err); }
-              fs.writeFile(cssPath, css, 'utf8', next);
+            res.writeHead(200, {
+                'Content-Type': 'text/css',
+                'Cache-Control': 'max-age=0'
             });
+            res.end(css);
+
           }, {
             include_paths: [ sassDir ].concat(options.include_paths || options.includePaths || []),
             image_path: options.image_path || options.imagePath,


### PR DESCRIPTION
Always write the compiled css to response, but `options.response` stops the file bring written to disk.

Currently the first request for a stylesheet (before it has been compiled) will 404. On the second run it will use the complied file. My changes mean that the first request will return the compiled css AND write to disk.

For backwards compatibility, using `options.response` will still write to response, but will not write to disk.
