### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Connect middleware for [node-sass](https://github.com/sass/node-sass)
 
 ## Install
 
-    npm install node-sass-middlware
+    npm install node-sass-middleware
 
 ## Usage
 


### PR DESCRIPTION
Typo in README.

Package name is mispelt as "node-sass-middlware" (not the lack of _e_)
