### PR TITLE
:bug: Add support for Node 0.12 and node-sass 2.0. Fixes #23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - '0.10'
-- '0.11'
+- '0.12'
 deploy:
   provider: npm
   email:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "mkdirp": "0.5.x",
-    "node-sass": "^1.0.0"
+    "node-sass": "^2.0.1"
   },
   "devDependencies": {
     "connect": "^2.25.7",

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -29,8 +29,7 @@ describe('Using middleware', function () {
   var server = connect()
     .use(middleware({
       src: __dirname,
-      dest: __dirname,
-      debug: true
+      dest: __dirname
     }));
 
   beforeEach(function (done) {

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -29,7 +29,8 @@ describe('Using middleware', function () {
   var server = connect()
     .use(middleware({
       src: __dirname,
-      dest: __dirname
+      dest: __dirname,
+      debug: true
     }));
 
   beforeEach(function (done) {
@@ -54,26 +55,26 @@ describe('Using middleware', function () {
 
     it('serves the compiled contents of the relative scss file', function (done) {
       var filesrc = fs.readFileSync(scssfile),
-          css = sass.renderSync(filesrc.toString());
+          result = sass.renderSync({ data: filesrc.toString() });
       request(server)
         .get('/test.css')
-        .expect(css)
+        .expect(result.css)
         .expect(200, done);
     });
 
     it('writes the file contents out to the expected file', function (done) {
       var filesrc = fs.readFileSync(scssfile),
-          css = sass.renderSync(filesrc.toString());
+          result = sass.renderSync({ data: filesrc.toString() });
       request(server)
         .get('/test.css')
-        .expect(css)
+        .expect(result.css)
         .expect(200, function (err) {
           if (err) {
             done(err);
           } else {
             (function checkFile() {
               if (fs.existsSync(cssfile)) {
-                fs.readFileSync(cssfile).toString().should.equal(css);
+                fs.readFileSync(cssfile).toString().should.equal(result.css);
                 done();
               } else {
                 setTimeout(checkFile, 25);


### PR DESCRIPTION
This PR adds support for Node 0.12 and node-sass 2.0.1.

Tests: :white_check_mark:

Fixes: https://github.com/sass/node-sass-middleware/issues/23

Ref: https://github.com/sass/node-sass/issues/656

PR-ready: :shipit: 