### PR TITLE
Control render errors and check imports correctly

### DIFF
--- a/test/index.css
+++ b/test/index.css
@@ -1,0 +1,12 @@
+body {
+  margin: 0; }
+  body ul {
+    margin: 0;
+    /* toss in a comment here */ }
+    body ul li {
+      list-style: none; }
+      body ul li a {
+        color: blue;
+        text-decoration: none; }
+        body ul li a:hover {
+          color: green; }

--- a/test/index.scss
+++ b/test/index.scss
@@ -1,0 +1,1 @@
+@import 'test.scss';

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -7,7 +7,9 @@ var fs = require('fs'),
     connect = require('connect'),
     middleware = require('../middleware'),
     cssfile = path.join(__dirname, '/test.css'),
-    scssfile = path.join(__dirname, '/test.scss');
+    scssfile = path.join(__dirname, '/test.scss'),
+    cssIndexFile = path.join(__dirname, '/index.css'),
+    scssDependentFile = path.join(__dirname, '/test.scss');
 
 describe('Creating middleware', function () {
 
@@ -94,6 +96,31 @@ describe('Using middleware', function () {
         .expect(404, done);
     });
 
+  });
+
+  describe('compiling files with dependences (source file contains includes)', function() {
+
+    it('any change in a dependent file, force recompiling', function(done) {
+
+      request(server)
+        .get('/index.css')
+        .expect(200, function() {
+          fs.stat(cssIndexFile, function(err, initialDate) {
+            // modify dependent file
+            fs.appendFile(scssDependentFile, '\n', function(err, data) {
+              if (err) throw err;
+              request(server)
+                .get('/index.css')
+                .expect(200, function() {
+                    fs.stat(cssIndexFile, function(err, endDate) {
+                      if (endDate.mtime > initialDate.mtime) done();
+                    });
+                });
+            });
+          });
+
+        });
+    });
   });
 
 });


### PR DESCRIPTION
SASS render function returns a result with the includedFiles into a “stats” object. This is an array width all file paths.
checkImports function need a new parameter with the css time to compare it.

Additionally, check the error when SASS renders and call a new error function that user can be passed into options object.
