### PR TITLE
Full support for all node-sass options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,18 @@ app.use(express.static(path.join(__dirname, 'public')));
  *    optional configurations:
   *    `dest`           - (String) Destination directory used to output `.css` files (when undefined defaults to `src`).
   *    `root`           - (String) A base path for both source and destination directories.
-  *    `outputStyle`    -`['nested' | 'compressed']`, `'nested'` by default. Sass output style.
-  *    `indentedSyntax` - `[true(.sass) | false(.scss)]`, false by default. Use standard SCSS sytax (Sassy CSS) or the cleaner SASS syntax.
-  *    `prefix`         - (String) It will tell the sass middleware that any request file will always be prefixed with `<prefix>` and this prefix should be ignored. 
-  *    `sourceMap`      - `[true | false]`, false by default. It will generate the sass sourcemap. 
+  *    `prefix`         - (String) It will tell the sass middleware that any request file will always be prefixed with `<prefix>` and this prefix should be ignored.
   *    `force`          - `[true | false]`, false by default. Always re-compile.
   *    `debug`          - `[true | false]`, false by default. Output debugging information.
   *    `response`       - `[true | false]`, true by default. To write output directly to response instead of to a file.
   *    `error`          - A function to be called when something goes wrong.
 
+  For full list of options from original node-sass project go [here](https://github.com/sass/node-sass).
+
 ## Testing
 
     npm install mocha -g
-    
+
     mocha test
 
 ## Contributors

--- a/middleware.js
+++ b/middleware.js
@@ -223,7 +223,7 @@ module.exports = function(options) {
           var style = options.compile();
 
           options.file = sassPath;
-          options.outFile = cssPath;
+          options.outFile = options.outFile || cssPath;
           options.includePaths = [sassDir].concat(options.includePaths || []);
 
           style.render(options, done);

--- a/middleware.js
+++ b/middleware.js
@@ -60,11 +60,12 @@ module.exports = function(options) {
   }
 
   var sassMiddlewareError = null;
+  var cachedErrorCb = options.error;
 
   // This function will be called if something goes wrong
   var error = function(err) {
-    if (options.error) {
-      options.error(err);
+    if (cachedErrorCb) {
+      cachedErrorCb(err);
     }
 
     sassMiddlewareError = err;

--- a/middleware.js
+++ b/middleware.js
@@ -86,6 +86,8 @@ module.exports = function(options) {
 
   var sassExtension = (options.indentedSyntax === true) ? '.sass' : '.scss';
 
+  var sourceMap = options.sourceMap || null;
+
   // Default compile callback
   options.compile = options.compile || function() {
     return sass;

--- a/middleware.js
+++ b/middleware.js
@@ -14,18 +14,19 @@ var imports = {};
  *
  * Options:
  *
+ *    all supportend options from node-sass project plus following:
+ *
  *    `src`            Source directory used to find .scss files
  *    `dest`           Destination directory used to output .css files when undefined defaults to `src`
  *    `root`           A base path for both source and destination directories
- *    `outputStyle`    Sass output style (nested or compressed), nested by default
- *    `indentedSyntax` Use standard SCSS sytax (Sassy CSS) or the cleaner SASS syntax
  *    `prefix`         It will tell the sass compiler that any request file will always be prefixed
  *                     with <prefix> and this prefix should be ignored.
- *    `sourceMap`      It will generate the sass sourcemap.
  *    `force`          Always re-compile
  *    `debug`          Output debugging information
  *    `response`       True (default) to write output directly to response instead of to a file
  *    `error`          A function to be called when something goes wrong
+ *
+ *
  *
  * Examples:
  *
@@ -83,10 +84,7 @@ module.exports = function(options) {
   // Enable debug output
   var debug = options.debug;
 
-  var indentedSyntax = options.indentedSyntax || null;
-  var sassExtension = (indentedSyntax === true) ? '.sass' : '.scss';
-
-  var sourceMap = options.sourceMap || null;
+  var sassExtension = (options.indentedSyntax === true) ? '.sass' : '.scss';
 
   // Default compile callback
   options.compile = options.compile || function() {
@@ -224,14 +222,11 @@ module.exports = function(options) {
 
           var style = options.compile();
 
-          style.render({
-            file: sassPath,
-            includePaths: [sassDir].concat(options.includePaths || []),
-            outputStyle: options.outputStyle,
-            indentedSyntax: indentedSyntax,
-            outFile: cssPath,
-            sourceMap: sourceMap,
-          }, done);
+          options.file = sassPath;
+          options.outFile = cssPath;
+          options.includePaths = [sassDir].concat(options.includePaths || []);
+
+          style.render(options, done);
         });
       };
 


### PR DESCRIPTION
Hi,

I made minor tweak to code so all user options are passed to `render()` method. This allows to use all node-sass options like setting precision factor, source comments, embeded source maps, add custom functions etc.

