### PR TITLE
Enables directly serving CSS from the compiled files, even if unmodified

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -5,7 +5,8 @@ var sass = require('node-sass'),
     url = require('url'),
     dirname = require('path').dirname,
     mkdirp = require('mkdirp'),
-    join = require('path').join;
+    join = require('path').join,
+    resolve = require('path').resolve;
 
 var imports = {};
 
@@ -101,11 +102,7 @@ module.exports = function(options) {
     }
 
     function serve() {
-      var path = cssPath;
-      if(path.charAt(0) !== "/") {
-        path = process.cwd() + "/" + path;
-      }
-      res.sendFile(path);
+      res.sendFile(resolve(cssPath));
     }
 
     var path = url.parse(req.url).pathname;

--- a/middleware.js
+++ b/middleware.js
@@ -100,6 +100,14 @@ module.exports = function(options) {
       return next();
     }
 
+    function serve() {
+      var path = cssPath;
+      if(path.charAt(0) !== "/") {
+        path = process.cwd() + "/" + path;
+      }
+      res.sendFile(path);
+    }
+
     var path = url.parse(req.url).pathname;
     if (options.prefix && 0 === path.indexOf(options.prefix)) {
       path = path.substring(options.prefix.length);
@@ -269,7 +277,13 @@ module.exports = function(options) {
                     log('modified import %s', path);
                   });
                 }
-                changed && changed.length ? compile() : next();
+                if(changed && changed.length) {
+                  compile();
+                } else if(!options.respond) {
+                  serve();
+                } else {
+                  next();
+                }
               });
             }
           }


### PR DESCRIPTION
This means you don't have to have something else, e.g. express.static, pointing at the CSS.

I wanted to keep compiled CSS out of my public assets folder, which I also use to store bootstrap etc, so that I didn't have to commit them to the repo or manually .gitignore each file.