### PR TITLE
Fix: middleware can't deal with more than one source file correctly

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var sass = require('node-sass'),
+    util = require('util'),
     fs = require('fs'),
     url = require('url'),
     dirname = require('path').dirname,
@@ -229,11 +230,13 @@ module.exports = function(options) {
 
         var style = options.compile();
 
-        options.file = sassPath;
-        options.outFile = options.outFile || cssPath;
-        options.includePaths = [sassDir].concat(options.includePaths || []);
+        var renderOptions = util._extend({}, options);
 
-        style.render(options, done);
+        renderOptions.file = sassPath;
+        renderOptions.outFile = options.outFile || cssPath;
+        renderOptions.includePaths = [sassDir].concat(options.includePaths || []);
+
+        style.render(renderOptions, done);
       });
     };
 


### PR DESCRIPTION
When rendering the first input file ``options.outFile`` is set once and later re-used
for every subsequent file.

This caused two problems:

1. When rendering ``fileA.sass`` and ``fileB.sass`` in that order, 
    the result of ``fileB.sass`` would overwrite ``fileA.css`` afaik.

I never really got that far since:

2. ``node-sass`` saves the callback in the supplied ``options`` object, overwriting the previous callback.
      When two ``.css`` were requested in parallel, this caused the callback of the first rendering
      process to be called twice and the callback of the second rendering process to be overwritten and
      hence never called. Which THEN caused ``done`` (our callback) to be called twice, leading to 
     ``Error: Can't set headers after they are sent.``

Here's the specific problematic line:

https://github.com/sass/node-sass-middleware/blob/22fa1d444d06e5c7b5913c35e39755029d1b736e/middleware.js#L233

As you can see we set ``outFile`` once and then re-use it for every subsequent rendering process.
We also pass our initial ``options`` object to ``node-sass``, which will save some own data in it causing problematic behavior when rendering more than one file at once.

This PR fixes that.
