### PR TITLE
Use C++11 compiler to fix TravisCI warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
-- '5'
+  - '0.10'
+  - '0.12'
+  - '5'
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 deploy:
   provider: npm
   email:


### PR DESCRIPTION
Warning (https://travis-ci.org/sass/node-sass-middleware/jobs/174273068):

> Starting with io.js 3 and Node.js 4, building native extensions
requires C++11-compatible compiler, which seems unavailable on this VM.
Please read https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements.