### PR TITLE
[#49] Fix Express example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ app.use(sassMiddleware({
 }));
 // Note: you must place sass-middleware *before* `express.static` or else it will
 // not work.
-app.use(express.static(path.join(__dirname, 'public')));
+app.use('/public', express.static(path.join(__dirname, 'public')));
 ```
 
 ### Connect with other middleware example


### PR DESCRIPTION
Fix the Express example in `README.md` w.r.t. to the problems discussed in #49.