### PR TITLE
Bump node-sass version - Provides Alpine support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
-    "node-sass": "^3.11.2"
+    "node-sass": "^4.1.1"
   },
   "devDependencies": {
     "connect": "^3.5.0",


### PR DESCRIPTION
The node-sass project provided Alpine support in 4.1.0. 
This change enables the use of node-sass-middleware on Alpine linux as well.

According to the [node-sass release notes](https://github.com/sass/node-sass/releases/tag/v4.0.0) 4.0.0 is backwards compatible with 3.4.0.