### PR TITLE
Skip early and log when prefix mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,19 @@ app.use(sassMiddleware({
 app.use(express.static(path.join(__dirname, 'public')));
 ```
 
-## Testing
-
-    npm install mocha -g
-
-    mocha test
-
 ## Contributors
 
 We <3 our contributors! A special thanks to all those who have clocked in some dev time on this project, we really appreciate your hard work. You can find [a full list of those people here](https://github.com/sass/node-sass-middleware/graphs/contributors).
+
+### Building and Testing
+
+```sh
+git clone git@github.com:sass/node-sass-middleware
+cd node-sass-middleware
+
+npm install
+npm test
+```
 
 ### Note on Patches/Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
-    "node-sass": "^4.1.1"
+    "node-sass": "^4.3.0"
   },
   "devDependencies": {
     "connect": "^3.5.0",


### PR DESCRIPTION
* If the requested file is not .css, log and skip (new: log, we were already skipping here)
* If the requested file does not starts with provided prefix, log and prefix (new)
* Provide reason for compile logs (new)
* Add more logger tests

Fixes #88