### PR TITLE
Disable beeping on error by default and add option to enable it

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,20 @@ http.createServer(app).listen(3000);
 ### Options
 
  *    `src`            - (String) Source directory used to find `.scss` or `.sass` files.
+ *
  *    optional configurations:
-  *    `dest`           - (String) Destination directory used to output `.css` files (when undefined defaults to `src`).
-  *    `root`           - (String) A base path for both source and destination directories.
-  *    `prefix`         - (String) It will tell the sass middleware that any request file will always be prefixed with `<prefix>` and this prefix should be ignored.
-  *    `force`          - `[true | false]`, false by default. Always re-compile.
-  *    `debug`          - `[true | false]`, false by default. Output debugging information.
-  *    `indentedSyntax` - `[true | false]`, false by default. Compiles files with the `.sass` extension instead of `.scss` in the `src` directory.
-  *    `response`       - `[true | false]`, true by default. To write output directly to response instead of to a file.
-  *    `error`          - A function to be called when something goes wrong.
-  *    `maxAge`         - MaxAge to be passed in Cache-Control header.
-  *    `log`            - `function(severity, key, val)`, used to log data instead of the default `console.error`
+ *
+ *    `beepOnError`    - Enable beep on error, false by default.
+ *    `debug`          - `[true | false]`, false by default. Output debugging information.
+ *    `dest`           - (String) Destination directory used to output `.css` files (when undefined defaults to `src`).
+ *    `error`          - A function to be called when something goes wrong.
+ *    `force`          - `[true | false]`, false by default. Always re-compile.
+ *    `indentedSyntax` - `[true | false]`, false by default. Compiles files with the `.sass` extension instead of `.scss` in the `src` directory.
+ *    `log`            - `function(severity, key, val)`, used to log data instead of the default `console.error`
+ *    `maxAge`         - MaxAge to be passed in Cache-Control header.
+ *    `prefix`         - (String) It will tell the sass middleware that any request file will always be prefixed with `<prefix>` and this prefix should be ignored.
+ *    `response`       - `[true | false]`, true by default. To write output directly to response instead of to a file.
+ *    `root`           - (String) A base path for both source and destination directories.
 
 
   For full list of options from original node-sass project go [here](https://github.com/sass/node-sass).

--- a/middleware.js
+++ b/middleware.js
@@ -17,17 +17,21 @@ var imports = {};
  *
  *    all supportend options from node-sass project plus following:
  *
- *    `src`            Source directory used to find .scss files
- *    `dest`           Destination directory used to output .css files when undefined defaults to `src`
- *    `root`           A base path for both source and destination directories
- *    `prefix`         It will tell the sass compiler that any request file will always be prefixed
- *                     with <prefix> and this prefix should be ignored.
- *    `force`          Always re-compile
- *    `debug`          Output debugging information
- *    `response`       True (default) to write output directly to response instead of to a file
- *    `error`          A function to be called when something goes wrong
- *    `maxAge`         MaxAge to be passed in Cache-Control header
- *    `log`            function(severity, key, val), used to log data instead of the default `console.error`
+ *    `src`            - (String) Source directory used to find `.scss` or `.sass` files.
+ *
+ *    optional configurations:
+ *
+ *    `beepOnError`    - Enable beep on error, false by default.
+ *    `debug`          - `[true | false]`, false by default. Output debugging information.
+ *    `dest`           - (String) Destination directory used to output `.css` files (when undefined defaults to `src`).
+ *    `error`          - A function to be called when something goes wrong.
+ *    `force`          - `[true | false]`, false by default. Always re-compile.
+ *    `indentedSyntax` - `[true | false]`, false by default. Compiles files with the `.sass` extension instead of `.scss` in the `src` directory.
+ *    `log`            - `function(severity, key, val)`, used to log data instead of the default `console.error`
+ *    `maxAge`         - MaxAge to be passed in Cache-Control header.
+ *    `prefix`         - (String) It will tell the sass middleware that any request file will always be prefixed with `<prefix>` and this prefix should be ignored.
+ *    `response`       - `[true | false]`, true by default. To write output directly to response instead of to a file.
+ *    `root`           - (String) A base path for both source and destination directories.
  *
  *
  * Examples:

--- a/middleware.js
+++ b/middleware.js
@@ -74,6 +74,8 @@ module.exports = function(options) {
   var force = options.force || options.response;
   // Enable debug output
   var debug = options.debug;
+  // Enable beep on error
+  var beep = options.beepOnError || false;
 
   var sassExtension = (options.indentedSyntax === true) ? '.sass' : '.scss';
 
@@ -160,7 +162,7 @@ module.exports = function(options) {
         }
 
         var fileLineColumn = file + ':' + err.line + ':' + err.column;
-        var errorMessage = '\x07\x1B[31m' + err.message.replace(/^ +/, '') + '\n\nin ' + fileLineColumn + '\x1B[91m';
+        var errorMessage = (beep ? '\x07' : '') + '\x1B[31m' + err.message.replace(/^ +/, '') + '\n\nin ' + fileLineColumn + '\x1B[91m';
 
         error(err, errorMessage);
         return next(err);

--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
-    "node-sass": "^4.3.0"
+    "node-sass": "^4.5.0"
   },
   "devDependencies": {
-    "connect": "^3.5.0",
-    "eslint": "^3.13.1",
-    "express": "^4.14.0",
+    "connect": "^3.6.0",
+    "eslint": "^3.17.0",
+    "express": "^4.15.0",
     "mocha": "^3.2.0",
-    "should": "^11.1.2",
-    "supertest": "^2.0.1"
+    "should": "^11.2.0",
+    "supertest": "^3.0.0"
   }
 }

--- a/test/fixtures/example-server.js
+++ b/test/fixtures/example-server.js
@@ -8,7 +8,8 @@ app.use(sassMiddleware({
   src: __dirname,
   dest: __dirname,
   debug: true,
-  outputStyle: 'compressed'
+  outputStyle: 'compressed',
+  beepOnError: true
 }));
 
 http.createServer(app).listen(port);

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -134,6 +134,31 @@ describe('Log messages', function() {
         done();
       });
   });
+
+  it('should produce beep ', function(done) {
+    this.timeout(this.timeout() + 55500);
+    // setup
+    var testScssFile = fixture('test2.scss');
+    var content = fs.readFileSync(fixture('test.scss')) + '\nbody { background;: red; }';
+    fs.writeFileSync(testScssFile, content, { flag: 'w' });
+
+    var expectedKey = '\x07\x1B';
+
+    http.request({ method: 'GET', host: 'localhost', port: process.env.PORT || '8000', path: '/test2.css' })
+        .end();
+
+    spawnedServer.stderr.on('data', function(data) {
+      // skip until we get the error
+      if(data.indexOf('[sass]  \x1B[90merror:') !== 0) {
+        return;
+      }
+
+      data.toString().should.containEql(expectedKey);
+
+      fs.unlinkSync(testScssFile);
+      done();
+    });
+  });
 });
 
 describe('Checking for http headers', function() {

--- a/test/sassTests.js
+++ b/test/sassTests.js
@@ -103,7 +103,7 @@ describe('Using middleware to compile .sass', function() {
     it('moves to next middleware', function(done) {
       request(server)
         .get('/does-not-exist.css')
-        .expect('Cannot GET /does-not-exist.css\n')
+        .expect('<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot GET /does-not-exist.css</pre>\n</body>\n')
         .expect(404, done);
     });
   });

--- a/test/scssTests.js
+++ b/test/scssTests.js
@@ -103,7 +103,7 @@ describe('Using middleware to compile .scss', function() {
     it('moves to next middleware', function(done) {
       request(server)
         .get('/does-not-exist.css')
-        .expect('Cannot GET /does-not-exist.css\n')
+        .expect('<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot GET /does-not-exist.css</pre>\n</body>\n')
         .expect(404, done);
     });
   });


### PR DESCRIPTION
I was just working on my website project and I kept hearing the Windows alert sound every few seconds. It took me nearly a half hour to figure out that it was coming from node-sass-middleware errors printing a `\x07` character before every console error.

This PR removes that character and adds an option to add it back if one so desires.