### PR TITLE
Bump node-sass from 6.0.1 to 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "node-sass": "^6.0.1"
+    "node-sass": "^7.0.1"
   },
   "devDependencies": {
     "connect": "^3.7.0",


### PR DESCRIPTION
Is there any possibility to upgrade the node-sass version to the latest? Which also add support for Node 16 & 17.