### PR TITLE
fix: update license property

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,7 @@
   "bugs": {
     "url": "https://github.com/sass/node-sass-middleware/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/sass/node-sass-middleware/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "main": "./middleware.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current format was a very old style that npmjs.org no longer parses correctly