### PR TITLE
Migrate to dart-sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-sass-middleware
 
-Connect/Express middleware for [node-sass](https://github.com/sass/node-sass).
+Connect/Express middleware for [dart-sass](https://github.com/sass/dart-sass).
 
 [![Main CI Workflow](https://github.com/sass/node-sass-middleware/actions/workflows/ci.yml/badge.svg)](https://github.com/sass/node-sass-middleware/actions/workflows/ci.yml)
 [![npm version](https://badge.fury.io/js/node-sass-middleware.svg)](http://badge.fury.io/js/node-sass-middleware)
@@ -109,7 +109,7 @@ http.createServer(app).listen(3000);
 * `response`       - `[true | false]`, true by default. To write output directly to response instead of to a file.
 * `root`           - (String) A base path for both source and destination directories.
 
-  For full list of options from original node-sass project go [here](https://github.com/sass/node-sass).
+  For full list of options from original dart-sass project go [here](https://github.com/sass/dart-sass).
 
 ### Express example with custom log function
 

--- a/middleware.js
+++ b/middleware.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var sass = require('node-sass'),
+var sass = require('sass'),
     util = require('util'),
     fs = require('fs'),
     url = require('url'),

--- a/middleware.js
+++ b/middleware.js
@@ -176,7 +176,7 @@ module.exports = function(options) {
       log('debug', 'render', options.response ? '<response>' : sassPath);
 
       if (sourceMap) {
-        log('debug', 'render', this.options.sourceMap);
+        log('debug', 'render', cssPath + '.map');
       }
       imports[sassPath] = result.stats.includedFiles;
 
@@ -227,7 +227,7 @@ module.exports = function(options) {
       });
 
       if (sourceMap) {
-        var sourceMapPath = this.options.sourceMap;
+        var sourceMapPath = cssPath + '.map';
         fs.mkdir(dirname(sourceMapPath), { mode: '0700', recursive: true}, function(err) {
           if (err) {
             error(err);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "node-sass": "^7.0.1"
+    "sass": "^1.52.3"
   },
   "devDependencies": {
     "connect": "^3.7.0",

--- a/test/scssTests.js
+++ b/test/scssTests.js
@@ -4,7 +4,7 @@
 var fs = require('fs'),
     path = require('path'),
     should = require('should'),
-    sass = require('node-sass'),
+    sass = require('sass'),
     request = require('supertest'),
     connect = require('connect'),
     middleware = require('../middleware'),
@@ -233,14 +233,25 @@ describe('Using middleware to compile .scss', function() {
     it('if error is in the main file', function(done) {
       request(server)
         .get('/test.css')
-        .expect('property "background" must be followed by a \':\'')
+        .expect('expected "{".\n' +
+        '   ╷\n' +
+        '21 │ body { background;: red; }\n' +
+        '   │                  ^\n' +
+        '   ╵\n' +
+        '  test\\fixtures\\test.scss 21:18  root stylesheet')
         .expect(500, done);
     });
 
     it('if error is in imported file', function(done) {
       request(server)
         .get('/index.css')
-        .expect('property "background" must be followed by a \':\'')
+        .expect('expected "{".\n' +
+        '   ╷\n' +
+        '21 │ body { background;: red; }\n' +
+        '   │                  ^\n' +
+        '   ╵\n' +
+        '  test\\fixtures\\test.scss 21:18  @import\n' +
+        '  test\\fixtures\\index.scss 1:9   root stylesheet')
         .expect(500, done);
     });
 


### PR DESCRIPTION
`node-sass` is deprecated and doesn't support some newer language features.

This PR replaces it with `sass`, and updates unit tests to match the new error messages/syntax rules.