### PR TITLE
Bump node-sass version to v9.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - 12
-          - 14
           - 16
+          - 18
+          - 19
+          - 20
 
         os:
           - ubuntu-latest
@@ -23,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - run: npm install
       - run: npm test
 
@@ -22,8 +22,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "url": "git://github.com/sass/node-sass-middleware.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": "^16 || >=18.0.0"
   },
   "dependencies": {
-    "node-sass": "^7.0.1"
+    "node-sass": "^9.0.0"
   },
   "devDependencies": {
     "connect": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   },
   "devDependencies": {
     "connect": "^3.7.0",
-    "eslint": "^7.32.0",
-    "express": "^4.17.1",
-    "mocha": "^7.2.0",
+    "eslint": "^8.42.0",
+    "express": "^4.18.2",
+    "mocha": "^10.2.0",
     "should": "^13.2.3",
-    "supertest": "^6.1.6"
+    "supertest": "^6.3.3"
   }
 }


### PR DESCRIPTION
Adds support for Node v18+, drops support for v14.